### PR TITLE
Fixes and stuff

### DIFF
--- a/Pal.Client/Configuration/AdditionalConfiguration.cs
+++ b/Pal.Client/Configuration/AdditionalConfiguration.cs
@@ -12,13 +12,19 @@ namespace Pal.Client.Configuration
 {
     public class AdditionalConfiguration : IEzConfig
     {
+        public bool GoldText = true;
+        public bool SilverText = true;
         public bool DisplayExit = false;
         public bool DisplayExitOnlyActive = false;
+        public bool ExitText = true;
         public bool TrapColorFilled = false;
         public bool BronzeShow = false;
         public bool BronzeFill = false;
-        public Vector4 BronzeColor = 4279786209.ToVector4();
+        public bool BronzeText = true;
+        public Vector4 BronzeColor = 0xFF185AE1.ToVector4();
+        public Vector4 MimicColor = 0xFF0000FF.ToVector4();
         public Vector4 TrapColor = 0xFF0000FF.ToVector4();
+        public Vector4 ExitColor = 0xFFFF00C8.ToVector4();
         public float OverlayFScale = 1.3f;
     }
 }

--- a/Pal.Client/ExternalUtils.cs
+++ b/Pal.Client/ExternalUtils.cs
@@ -24,10 +24,13 @@ namespace Pal.Client
                 foreach(var x in BronzeCofferDataID)
                 {
                     var element = Splatoon.DecodeElement("{\"Name\":\"Bronze Treasure Coffer\",\"type\":1,\"color\":4279786209,\"overlayBGColor\":0,\"overlayTextColor\":4279786209,\"overlayVOffset\":0.6,\"overlayFScale\":1.3,\"overlayText\":\" Bronze Treasure Coffer\",\"refActorComparisonType\":3,\"includeOwnHitbox\":true}");
+                    if (!P.Config.BronzeText)
+                        element.overlayText = "";
                     element.refActorDataID = x;
                     var elementFill = Splatoon.DecodeElement("{\"Name\":\"Bronze Treasure Coffer Fill\",\"type\":1,\"color\":840456929,\"overlayVOffset\":0.68,\"overlayFScale\":1.24,\"FillStep\":0.429,\"refActorComparisonType\":3,\"includeOwnHitbox\":true,\"Filled\":true}");
                     elementFill.refActorDataID = x;
                     element.color = P.Config.BronzeColor.ToUint();
+                    element.overlayTextColor = P.Config.BronzeColor.ToUint();
                     elementFill.color = (P.Config.BronzeColor with { W = P.Config.BronzeColor.W / 2f }).ToUint();
                     Splatoon.AddDynamicElement(BronzeTreasureNamespace, element, 0);
                     if (P.Config.BronzeFill)
@@ -37,15 +40,20 @@ namespace Pal.Client
                 }
 
                 {
-                    var e = Splatoon.DecodeElement("{\"Name\":\"Mimic Trap Coffer\",\"type\":1,\"color\":4278190335,\"overlayBGColor\":0,\"overlayTextColor\":4278190335,\"overlayVOffset\":0.6,\"overlayFScale\":1.3,\"overlayText\":\" Mimic Trap Coffer\",\"refActorDataID\":2006020,\"FillStep\":0.029,\"refActorComparisonType\":3,\"includeOwnHitbox\":true,\"AdditionalRotation\":0.43633232}");
-                    e.overlayFScale = P.Config.OverlayFScale;
-                    Splatoon.AddDynamicElement(BronzeTreasureNamespace, e, 0);
-                }
-                if (P.Config.BronzeFill)
-                {
-                    var e = Splatoon.DecodeElement("{\"Name\":\"Mimic Trap Coffer Fill\",\"type\":1,\"color\":838861055,\"overlayBGColor\":0,\"overlayTextColor\":4278190335,\"overlayVOffset\":0.6,\"overlayFScale\":1.3,\"refActorDataID\":2006020,\"FillStep\":0.029,\"refActorComparisonType\":3,\"includeOwnHitbox\":true,\"AdditionalRotation\":0.43633232,\"Filled\":true}");
-                    e.overlayFScale = P.Config.OverlayFScale;
-                    Splatoon.AddDynamicElement(BronzeTreasureNamespace, e, 0);
+                    var element = Splatoon.DecodeElement("{\"Name\":\"Mimic Trap Coffer\",\"type\":1,\"color\":4278190335,\"overlayBGColor\":0,\"overlayTextColor\":4278190335,\"overlayVOffset\":0.6,\"overlayFScale\":1.3,\"overlayText\":\" Mimic Trap Coffer\",\"refActorDataID\":2006020,\"FillStep\":0.029,\"refActorComparisonType\":3,\"includeOwnHitbox\":true,\"AdditionalRotation\":0.43633232}");
+                    if (!P.Config.BronzeText)
+                        element.overlayText = "";
+                    element.color = P.Config.MimicColor.ToUint();
+                    element.overlayTextColor = P.Config.MimicColor.ToUint();
+                    element.overlayFScale = P.Config.OverlayFScale;
+                    Splatoon.AddDynamicElement(BronzeTreasureNamespace, element, 0);
+                    if (P.Config.BronzeFill)
+                    {
+                        var elementFill = Splatoon.DecodeElement("{\"Name\":\"Mimic Trap Coffer Fill\",\"type\":1,\"color\":838861055,\"overlayBGColor\":0,\"overlayTextColor\":4278190335,\"overlayVOffset\":0.6,\"overlayFScale\":1.3,\"refActorDataID\":2006020,\"FillStep\":0.029,\"refActorComparisonType\":3,\"includeOwnHitbox\":true,\"AdditionalRotation\":0.43633232,\"Filled\":true}");
+                        elementFill.color = (P.Config.MimicColor with { W = P.Config.MimicColor.W / 2f }).ToUint();
+                        elementFill.overlayFScale = P.Config.OverlayFScale;
+                        Splatoon.AddDynamicElement(BronzeTreasureNamespace, elementFill, 0);
+                    }
                 }
             }
         }

--- a/Pal.Client/Floors/FrameworkService.cs
+++ b/Pal.Client/Floors/FrameworkService.cs
@@ -317,9 +317,6 @@ namespace Pal.Client.Floors
 
         private void CreateRenderElement(MemoryLocation location, List<SplatoonElement> elements, uint color, MarkerConfiguration config)
         {
-            if (!config.Show)
-                return;
-
             var element = _renderAdapter.CreateElement(location.Type, location.Position, color, config.Fill);
             if(location.Type == MemoryLocation.EType.GoldCoffer)
             {
@@ -341,7 +338,7 @@ namespace Pal.Client.Floors
                 element2.Delegate.radius = 1f;
                 element2.Delegate.Filled = true;
                 location.RenderElement2 = element2;
-                if (config.Fill)
+                if (config.Show && config.Fill)
                 {
                     elements.Add(element2);
                 }
@@ -368,7 +365,7 @@ namespace Pal.Client.Floors
                 element2.Delegate.radius = 1f;
                 element2.Delegate.Filled = true;
                 location.RenderElement2 = element2;
-                if (config.Fill)
+                if (config.Show && config.Fill)
                 {
                     elements.Add(element2);
                 }
@@ -386,13 +383,15 @@ namespace Pal.Client.Floors
                 element2.Delegate.color = (P.Config.TrapColor with { W = 50f/255f }).ToUint();
                 element2.Delegate.Filled = true;
                 location.RenderElement2 = element2;
-                if (config.Fill)
+                if (config.Show && config.Fill)
                 {
                     elements.Add(element2);
                 }
             }
             location.RenderElement = element;
-            elements.Add(element); 
+
+            if (config.Show)
+                elements.Add(element);
         }
 
         #endregion

--- a/Pal.Client/Floors/FrameworkService.cs
+++ b/Pal.Client/Floors/FrameworkService.cs
@@ -325,11 +325,14 @@ namespace Pal.Client.Floors
                 {"Name":"Gold Treasure Coffer Fill","type":1,"Enabled":false,"color":838913279,"overlayVOffset":0.68,"overlayFScale":1.24,"refActorPlaceholder":["<t>"],"FillStep":0.429,"refActorComparisonType":5,"includeOwnHitbox":true,"Filled":true}
                 */
                 element.Delegate.color = color;
-                element.Delegate.overlayBGColor = 0;
-                element.Delegate.overlayVOffset = 0.6f;
-                element.Delegate.overlayFScale = P.Config.OverlayFScale;
-                element.Delegate.overlayText = " Gold Treasure Coffer";
-                element.Delegate.overlayTextColor = color;
+                if (P.Config.GoldText)
+                {
+                    element.Delegate.overlayBGColor = 0;
+                    element.Delegate.overlayVOffset = 0.6f;
+                    element.Delegate.overlayFScale = P.Config.OverlayFScale;
+                    element.Delegate.overlayText = " Gold Treasure Coffer";
+                    element.Delegate.overlayTextColor = color;
+                }
                 element.Delegate.radius = 1f;
                 element.Delegate.Filled = false;
 
@@ -352,11 +355,14 @@ namespace Pal.Client.Floors
 
                  * */
                 element.Delegate.color = color;
-                element.Delegate.overlayBGColor = 0;
-                element.Delegate.overlayVOffset = 0.6f;
-                element.Delegate.overlayFScale = P.Config.OverlayFScale;
-                element.Delegate.overlayText = " Silver Treasure Coffer";
-                element.Delegate.overlayTextColor = color;
+                if (P.Config.SilverText)
+                {
+                    element.Delegate.overlayBGColor = 0;
+                    element.Delegate.overlayVOffset = 0.6f;
+                    element.Delegate.overlayFScale = P.Config.OverlayFScale;
+                    element.Delegate.overlayText = " Silver Treasure Coffer";
+                    element.Delegate.overlayTextColor = color;
+                }
                 element.Delegate.radius = 1f;
                 element.Delegate.Filled = false;
 

--- a/Pal.Client/Pal.Client.csproj
+++ b/Pal.Client/Pal.Client.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net7.0-windows</TargetFramework>
+		<EnableWindowsTargeting>true</EnableWindowsTargeting>
 		<LangVersion>11.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
@@ -57,7 +58,7 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\Pal.Common\Pal.Common.csproj" />
 	  <ProjectReference Include="..\ECommons\ECommons\ECommons.csproj" />
-	  <ProjectReference Include="..\punishLib\PunishLib\PunishLib.csproj" />
+	  <ProjectReference Include="..\PunishLib\PunishLib\PunishLib.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -66,38 +67,44 @@
 		<Protobuf Include="..\Pal.Common\Protos\export.proto" Link="Protos\export.proto" GrpcServices="Client" Access="Internal" />
 	</ItemGroup>
 
+	<PropertyGroup>
+		<DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+		<DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(HOME)/.xlcore/dalamud/Hooks/dev/</DalamudLibPath>
+		<DalamudLibPath Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(HOME)/Library/Application Support/XIV on Mac/dalamud/Hooks/dev/</DalamudLibPath>
+		<DalamudLibPath Condition="$(DALAMUD_HOME) != ''">$(DALAMUD_HOME)/</DalamudLibPath>
+	</PropertyGroup>
+
 	<ItemGroup>
-		<!--You may need to adjust these paths yourself. These point to a Dalamud assembly in AppData.-->
 		<Reference Include="Dalamud">
-			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
+			<HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
 			<Private Condition="'$(Configuration)' != 'EF'">false</Private>
 		</Reference>
 		<Reference Include="ImGui.NET">
-			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\ImGui.NET.dll</HintPath>
+			<HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
 			<Private Condition="'$(Configuration)' != 'EF'">false</Private>
 		</Reference>
 		<Reference Include="ImGuiScene">
-			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\ImGuiScene.dll</HintPath>
+			<HintPath>$(DalamudLibPath)ImGuiScene.dll</HintPath>
 			<Private Condition="'$(Configuration)' != 'EF'">false</Private>
 		</Reference>
 		<Reference Include="Lumina">
-			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Lumina.dll</HintPath>
+			<HintPath>$(DalamudLibPath)Lumina.dll</HintPath>
 			<Private Condition="'$(Configuration)' != 'EF'">false</Private>
 		</Reference>
 		<Reference Include="Lumina.Excel">
-			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Lumina.Excel.dll</HintPath>
+			<HintPath>$(DalamudLibPath)Lumina.Excel.dll</HintPath>
 			<Private Condition="'$(Configuration)' != 'EF'">false</Private>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
-			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Newtonsoft.Json.dll</HintPath>
+			<HintPath>$(DalamudLibPath)Newtonsoft.Json.dll</HintPath>
 			<Private Condition="'$(Configuration)' != 'EF'">false</Private>
 		</Reference>
 		<Reference Include="FFXIVClientStructs">
-			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\FFXIVClientStructs.dll</HintPath>
+			<HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
 			<Private Condition="'$(Configuration)' != 'EF'">false</Private>
 		</Reference>
 		<Reference Include="Serilog">
-			<HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Serilog.dll</HintPath>
+			<HintPath>$(DalamudLibPath)Serilog.dll</HintPath>
 			<Private Condition="'$(Configuration)' != 'EF'">false</Private>
 		</Reference>
 	</ItemGroup>

--- a/Pal.Client/Properties/Localization.Designer.cs
+++ b/Pal.Client/Properties/Localization.Designer.cs
@@ -910,6 +910,15 @@ namespace Pal.Client.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exit Outline Colour.
+        /// </summary>
+        internal static string pnExit_Outline_Colour {
+            get {
+                return ResourceManager.GetString("pnExit Outline Colour", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hide Accursed Hoard Locations on Intuition Use.
         /// </summary>
         internal static string pnHide_Accursed_Hoard_Locations_on_Intuition_Use {
@@ -964,11 +973,38 @@ namespace Pal.Client.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bronze Mimic Trap Coffer color.
+        /// </summary>
+        internal static string pnMimic_Coffer_color {
+            get {
+                return ResourceManager.GetString("pnMimic Coffer color", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only mimics in bronze chests on early floor sets can be detected..
+        /// </summary>
+        internal static string pnMimic_Help {
+            get {
+                return ResourceManager.GetString("pnMimic Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Passages.
         /// </summary>
         internal static string pnPassages {
             get {
                 return ResourceManager.GetString("pnPassages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text overlay.
+        /// </summary>
+        internal static string pnText_overlay {
+            get {
+                return ResourceManager.GetString("pnText overlay", resourceCulture);
             }
         }
         

--- a/Pal.Client/Properties/Localization.resx
+++ b/Pal.Client/Properties/Localization.resx
@@ -470,7 +470,7 @@ This is not synchronized with other players and not saved between floors/runs.</
     <value>Highlight When Activated</value>
   </data>
   <data name="pnHighlight When Activated Help" xml:space="preserve">
-    <value>By default the Passage will be marked only with a yellow outline and text label, enabling this will also enable a bright green fill.</value>
+    <value>By default the Passage will be marked only with an outline and text label, enabling this will also enable a bright green fill.</value>
   </data>
   <data name="pnPassages" xml:space="preserve">
     <value>Passages</value>

--- a/Pal.Client/Properties/Localization.resx
+++ b/Pal.Client/Properties/Localization.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -421,6 +421,12 @@ This is not synchronized with other players and not saved between floors/runs.</
   <data name="pnBronze Coffer color" xml:space="preserve">
     <value>Bronze Coffer color</value>
   </data>
+  <data name="pnMimic Coffer color" xml:space="preserve">
+    <value>Bronze Mimic Trap Coffer color</value>
+  </data>
+  <data name="pnMimic Help" xml:space="preserve">
+    <value>Only mimics in bronze chests on early floor sets can be detected.</value>
+  </data>
   <data name="pnCoffers" xml:space="preserve">
     <value>Coffers</value>
   </data>
@@ -477,5 +483,11 @@ This is not synchronized with other players and not saved between floors/runs.</
   </data>
   <data name="pnTraps" xml:space="preserve">
     <value>Traps</value>
+  </data>
+  <data name="pnText overlay" xml:space="preserve">
+    <value>Text overlay</value>
+  </data>
+  <data name="pnExit Outline Colour" xml:space="preserve">
+    <value>Exit Outline Colour</value>
   </data>
 </root>

--- a/Pal.Client/Rendering/SplatoonRenderer.cs
+++ b/Pal.Client/Rendering/SplatoonRenderer.cs
@@ -177,6 +177,10 @@ namespace Pal.Client.Rendering
             ResetLayer(ELayer.RegularCoffers);
             ResetLayer(ELayer.Test);
 
+            // Clean up the extra elements as well
+            Splatoon.RemoveDynamicElements("PalacePal.ExitElement");
+            Splatoon.RemoveDynamicElements("PalacePal.BronzeTreasure");
+
             //ECommonsMain.Dispose();
         }
 

--- a/Pal.Client/Rendering/SplatoonRenderer.cs
+++ b/Pal.Client/Rendering/SplatoonRenderer.cs
@@ -184,64 +184,40 @@ namespace Pal.Client.Rendering
         {
             const string Name = "PalacePal.ExitElement";
             Splatoon.RemoveDynamicElements(Name);
-            PluginLog.Debug($"Removing exit objects");
             if (Plugin.P.Config.DisplayExit)
             {
                 if (Enum.GetValues<ETerritoryType>().Contains((ETerritoryType)Svc.ClientState.TerritoryType))
                 {
-                    PluginLog.Debug($"Adding exit objects");
                     uint[] IDs = new uint[] { 2007188, 2009507, 2013287 };
                     foreach (var x in IDs)
                     {
-                        PluginLog.Debug($"Adding exit object {x}");
+                        Splatoon.AddDynamicElement(Name, new Element(ElementType.CircleRelativeToActorPosition)
+                        {
+                            radius = 2.0f,
+                            color = Plugin.P.Config.ExitColor.ToUint(),
+                            overlayVOffset = 0.76f,
+                            overlayText = Plugin.P.Config.ExitText ? "Passage" : "",
+                            overlayFScale = P.Config.OverlayFScale,
+                            refActorComparisonType = RefActorComparisonType.DataID,
+                            refActorDataID = x,
+                            includeHitbox = false,
+                        }, 0);
+
                         if (Plugin.P.Config.DisplayExitOnlyActive)
                         {
                             Splatoon.AddDynamicElement(Name, new Element(ElementType.CircleRelativeToActorPosition)
                             {
-                                radius = 2.1f,
-                                color = Plugin.P.Config.ExitColor.ToUint(),
-                                overlayVOffset = 0.76f,
-                                overlayText = Plugin.P.Config.ExitText ? "Passage" : "",
-                                overlayFScale = P.Config.OverlayFScale,
-                                refActorComparisonType = RefActorComparisonType.DataID,
+                                radius = 2.0f,
+                                color = 1684471552,
                                 refActorDataID = x,
-                                includeHitbox = true,
+                                includeHitbox = false,
+                                Filled = true,
                                 refActorComparisonAnd = true,
                                 refActorObjectEffectData1 = 4,
                                 refActorObjectEffectData2 = 8,
                                 refActorObjectEffectMax = int.MaxValue,
-                            }, 0) ;
-                        }
-                        else
-                        {
-                            Splatoon.AddDynamicElement(Name, new Element(ElementType.CircleRelativeToActorPosition)
-                            {
-                                radius = 2.1f,
-                                color = Plugin.P.Config.ExitColor.ToUint(),
-                                overlayVOffset = 0.76f,
-                                overlayText = Plugin.P.Config.ExitText ? "Passage" : "",
-                                overlayFScale = P.Config.OverlayFScale,
-                                refActorComparisonType = RefActorComparisonType.DataID,
-                                refActorDataID = x,
-                                includeHitbox = true,
                             }, 0);
                         }
-                        Splatoon.AddDynamicElement(Name, new Element(ElementType.CircleRelativeToActorPosition)
-                        {
-                            radius = 2.1f,
-                            color = 1684471552,
-                            overlayVOffset = 0.76f,
-                            overlayText = Plugin.P.Config.ExitText ? "ACTIVE" : "",
-                            overlayFScale = P.Config.OverlayFScale,
-                            refActorDataID = x,
-                            includeHitbox = true,
-                            Filled = true,
-                            refActorComparisonAnd = true,
-                            refActorObjectEffectData1 = 4,
-                            refActorObjectEffectData2 = 8,
-                            refActorObjectEffectMax = int.MaxValue,
-                        }, 0);
-
                     }
                 }
             }

--- a/Pal.Client/Rendering/SplatoonRenderer.cs
+++ b/Pal.Client/Rendering/SplatoonRenderer.cs
@@ -199,9 +199,9 @@ namespace Pal.Client.Rendering
                             Splatoon.AddDynamicElement(Name, new Element(ElementType.CircleRelativeToActorPosition)
                             {
                                 radius = 2.1f,
-                                color = 3355498751,
+                                color = Plugin.P.Config.ExitColor.ToUint(),
                                 overlayVOffset = 0.76f,
-                                overlayText = "Passage",
+                                overlayText = Plugin.P.Config.ExitText ? "Passage" : "",
                                 overlayFScale = P.Config.OverlayFScale,
                                 refActorComparisonType = RefActorComparisonType.DataID,
                                 refActorDataID = x,
@@ -217,9 +217,9 @@ namespace Pal.Client.Rendering
                             Splatoon.AddDynamicElement(Name, new Element(ElementType.CircleRelativeToActorPosition)
                             {
                                 radius = 2.1f,
-                                color = 3355498751,
+                                color = Plugin.P.Config.ExitColor.ToUint(),
                                 overlayVOffset = 0.76f,
-                                overlayText = "Passage",
+                                overlayText = Plugin.P.Config.ExitText ? "Passage" : "",
                                 overlayFScale = P.Config.OverlayFScale,
                                 refActorComparisonType = RefActorComparisonType.DataID,
                                 refActorDataID = x,
@@ -231,7 +231,7 @@ namespace Pal.Client.Rendering
                             radius = 2.1f,
                             color = 1684471552,
                             overlayVOffset = 0.76f,
-                            overlayText = "ACTIVE",
+                            overlayText = Plugin.P.Config.ExitText ? "ACTIVE" : "",
                             overlayFScale = P.Config.OverlayFScale,
                             refActorDataID = x,
                             includeHitbox = true,
@@ -241,7 +241,7 @@ namespace Pal.Client.Rendering
                             refActorObjectEffectData2 = 8,
                             refActorObjectEffectMax = int.MaxValue,
                         }, 0);
-                        
+
                     }
                 }
             }

--- a/Pal.Client/Windows/ConfigWindow.cs
+++ b/Pal.Client/Windows/ConfigWindow.cs
@@ -102,6 +102,7 @@ namespace Pal.Client.Windows
             SizeCondition = ImGuiCond.FirstUseEver;
             Position = new Vector2(300, 300);
             PositionCondition = ImGuiCond.FirstUseEver;
+            Flags = ImGuiWindowFlags.NoScrollbar;
 
             _importDialog = new FileDialogManager
             { AddedWindowFlags = ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoDocking };
@@ -169,7 +170,10 @@ namespace Pal.Client.Windows
                     if (ThreadLoadImageHandler.TryGetTextureWrap(imagePath, out var logo))
                     {
                         ImGuiEx.ImGuiLineCentered("###Logo", () => { ImGui.Image(logo.ImGuiHandle, new(125f.Scale(), 125f.Scale())); });
-
+                    }
+                    else
+                    {
+                        ImGuiEx.ImGuiLineCentered("###Logo", () => { ImGui.Dummy(new(125f.Scale(), 125f.Scale())); });
                     }
 
                     ImGui.Spacing();
@@ -194,7 +198,7 @@ namespace Pal.Client.Windows
 
                 ImGui.PopStyleVar(2);
                 ImGui.TableNextColumn();
-                if (ImGui.BeginChild($"###PPRight", Vector2.Zero, false, (false ? ImGuiWindowFlags.AlwaysVerticalScrollbar : ImGuiWindowFlags.None) | ImGuiWindowFlags.NoDecoration))
+                if (ImGui.BeginChild($"###PPRight", Vector2.Zero, false))
                 {
                     switch (OpenWindow)
                     {

--- a/Pal.Client/Windows/ConfigWindow.cs
+++ b/Pal.Client/Windows/ConfigWindow.cs
@@ -179,6 +179,9 @@ namespace Pal.Client.Windows
                     {
                         if ((OpenWindow)window == OpenWindow.None) continue;
 
+                        if ((OpenWindow)window == OpenWindow.Export && !_configuration.HasRoleOnCurrentServer(RemoteApi.RemoteUrl, "export:run"))
+                            continue;
+
                         if (ImGui.Selectable($"{string.Join(" ", window.ToString().SplitCamelCase())}", OpenWindow == (OpenWindow)window))
                         {
                             OpenWindow = (OpenWindow)window;

--- a/Pal.Client/Windows/ConfigWindow.cs
+++ b/Pal.Client/Windows/ConfigWindow.cs
@@ -3,6 +3,7 @@ using Dalamud.Interface;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Interface.Windowing;
+using Dalamud.Plugin.Services;
 using ECommons;
 using ECommons.Configuration;
 using ECommons.ImGuiMethods;
@@ -39,6 +40,7 @@ namespace Pal.Client.Windows
         private readonly WindowSystem _windowSystem;
         private readonly ConfigurationManager _configurationManager;
         private readonly IPalacePalConfiguration _configuration;
+        private readonly IClientState _clientState;
         private readonly RenderAdapter _renderAdapter;
         private readonly TerritoryState _territoryState;
         private readonly FrameworkService _frameworkService;
@@ -72,6 +74,7 @@ namespace Pal.Client.Windows
             ILogger<ConfigWindow> logger,
             WindowSystem windowSystem,
             ConfigurationManager configurationManager,
+            IClientState clientState,
             IPalacePalConfiguration configuration,
             RenderAdapter renderAdapter,
             TerritoryState territoryState,
@@ -86,6 +89,7 @@ namespace Pal.Client.Windows
             _logger = logger;
             _windowSystem = windowSystem;
             _configurationManager = configurationManager;
+            _clientState = clientState;
             _configuration = configuration;
             _renderAdapter = renderAdapter;
             _territoryState = territoryState;
@@ -143,7 +147,6 @@ namespace Pal.Client.Windows
             _exportDialog.Reset();
             _testConnectionCts?.Cancel();
             _testConnectionCts = null;
-            EzConfig.Save();
         }
 
         public override void Draw()
@@ -239,6 +242,7 @@ namespace Pal.Client.Windows
                 _configuration.DeepDungeons.GoldCoffers = _goldConfig.Build();
 
                 _configurationManager.Save(_configuration);
+                EzConfig.Save();
 
                 if (saveAndClose)
                     IsOpen = false;
@@ -278,7 +282,8 @@ namespace Pal.Client.Windows
                 ImGui.Checkbox(Localization.Config_GoldCoffer_Show, ref _goldConfig.Show);
                 ImGuiComponents.HelpMarker(Localization.Config_GoldCoffers_ToolTip);
                 Spacing(true); ImGui.ColorEdit4(Localization.Config_GoldCoffer_Color, ref _goldConfig.Color, ImGuiColorEditFlags.NoInputs);
-                Spacing(); ImGui.Checkbox(Localization.Config_GoldCoffer_Filled, ref _goldConfig.Fill);
+                Spacing(true); ImGui.Checkbox(Localization.Config_GoldCoffer_Filled, ref _goldConfig.Fill);
+                Spacing(); ImGui.Checkbox(Localization.pnText_overlay, ref P.Config.GoldText);
                 ImGui.PopID();
 
                 ImGui.Separator();
@@ -287,16 +292,20 @@ namespace Pal.Client.Windows
                 ImGui.Checkbox(Localization.Config_SilverCoffer_Show, ref _silverConfig.Show);
                 ImGuiComponents.HelpMarker(Localization.Config_SilverCoffers_ToolTip);
                 Spacing(true); ImGui.ColorEdit4(Localization.Config_SilverCoffer_Color, ref _silverConfig.Color, ImGuiColorEditFlags.NoInputs);
-                Spacing(); ImGui.Checkbox(Localization.Config_SilverCoffer_Filled, ref _silverConfig.Fill);
+                Spacing(true); ImGui.Checkbox(Localization.Config_SilverCoffer_Filled, ref _silverConfig.Fill);
+                Spacing(); ImGui.Checkbox(Localization.pnText_overlay, ref P.Config.SilverText);
                 ImGui.PopID();
 
                 ImGui.Separator();
 
                 ImGui.PushID("coffer3");
-                ImGui.Checkbox(Localization.pnDisplay_Bronze_Treasure_Coffer_Locations, ref P.Config.BronzeShow);
+                if (ImGui.Checkbox(Localization.pnDisplay_Bronze_Treasure_Coffer_Locations, ref P.Config.BronzeShow)) UpdateRender();
                 //ImGuiComponents.HelpMarker(Localization.Config_SilverCoffers_ToolTip);
-                Spacing(true); ImGui.ColorEdit4(Localization.pnBronze_Coffer_color, ref P.Config.BronzeColor, ImGuiColorEditFlags.NoInputs);
-                Spacing(); ImGui.Checkbox(Localization.Config_SilverCoffer_Filled, ref P.Config.BronzeFill);
+                Spacing(true); if (ImGui.ColorEdit4(Localization.pnBronze_Coffer_color, ref P.Config.BronzeColor, ImGuiColorEditFlags.NoInputs)) UpdateRender();
+                Spacing(true); if (ImGui.ColorEdit4(Localization.pnMimic_Coffer_color, ref P.Config.MimicColor, ImGuiColorEditFlags.NoInputs)) UpdateRender();
+                ImGuiComponents.HelpMarker(Localization.pnMimic_Help);
+                Spacing(true); if (ImGui.Checkbox(Localization.Config_SilverCoffer_Filled, ref P.Config.BronzeFill)) UpdateRender();
+                Spacing(); if (ImGui.Checkbox(Localization.pnText_overlay, ref P.Config.BronzeText)) UpdateRender();
                 ImGui.PopID();
 
                 ImGuiGroup.EndGroupBox();
@@ -307,8 +316,10 @@ namespace Pal.Client.Windows
             if (ImGuiGroup.BeginGroupBox())
             {
                 if (ImGui.Checkbox(Localization.pnDisplay_Passages, ref P.Config.DisplayExit)) UpdateRender();
-                Spacing(); if (ImGui.Checkbox(Localization.pnHighlight_When_Activated, ref P.Config.DisplayExitOnlyActive)) UpdateRender();
+                Spacing(true); if (ImGui.ColorEdit4(Localization.pnExit_Outline_Colour, ref P.Config.ExitColor, ImGuiColorEditFlags.NoInputs)) UpdateRender();
+                Spacing(true); if (ImGui.Checkbox(Localization.pnHighlight_When_Activated, ref P.Config.DisplayExitOnlyActive)) UpdateRender();
                 ImGuiComponents.HelpMarker(Localization.pnHighlight_When_Activated_Help);
+                Spacing(); if (ImGui.Checkbox(Localization.pnText_overlay, ref P.Config.ExitText)) UpdateRender();
                 ImGuiGroup.EndGroupBox();
             }
 
@@ -332,7 +343,11 @@ namespace Pal.Client.Windows
 
         }
 
-        void UpdateRender() => Plugin.P._rootScope!.ServiceProvider.GetRequiredService<RenderAdapter>()._implementation.UpdateExitElement();
+        private void UpdateRender()
+        {
+            Plugin.P._rootScope!.ServiceProvider.GetRequiredService<RenderAdapter>()._implementation.UpdateExitElement();
+            ExternalUtils.UpdateBronzeTreasureCoffers(_clientState.TerritoryType);
+        }
 
         private void DrawCommunityTab(ref bool saveAndClose)
         {


### PR DESCRIPTION
- Hide the Export tab instead of showing a blank page
- Avoid re-creating the trap/hoard elements every frame if hoard location display is disabled
	- Also fixes sight/safety not working in this case
- Fix scroll bar on the settings window, also reserve the logo space to avoid the menu jumping around
- Save the extra config stuff when clicking save rather than when closing the window
- Added options to hide overlay text and configure some more colors
- Make exit portal highlighting work as described (green highlight only when active), and not show overlapping text
- Default exit portal color is purple to not be confused with gold coffers
- Clean up bronze coffer and exit portal elements on plugin stop

also updated the build system to work out of the box on linux using the standard setup from Dalamud / SamplePlugin